### PR TITLE
[test] Update CHRONICLER_EVENTIZERS value for tests

### DIFF
--- a/tests/test_eventizer.py
+++ b/tests/test_eventizer.py
@@ -100,7 +100,7 @@ class TestEventize(unittest.TestCase):
     """Unit tests for eventize function"""
 
     def setUp(self) -> None:
-        os.environ['CHRONICLER_EVENTIZERS'] = 'tests.events_test_pck'
+        os.environ['CHRONICLER_EVENTIZERS'] = 'events_test_pck'
 
     def tearDown(self) -> None:
         os.environ['CHRONICLER_EVENTIZERS'] = 'chronicler.events'


### PR DESCRIPTION
This commit updates the value of CHRONICLER_EVENTIZERS to resolve an issue encountered when testing with the built package.
    
The tests are executed inside the tests directory, so the `tests.events_test_pck` module couldn't be found.