### PR TITLE
Update event ID generation for Git actions

### DIFF
--- a/chronicler/events/core/git.py
+++ b/chronicler/events/core/git.py
@@ -116,7 +116,11 @@ class GitEventizer(Eventizer):
         else:
             raise ValueError(f"No valid action: {action}")
 
-        event_id = uuid(event_uuid, file_data['file'], action)
+        id_args = [event_uuid, file_data['file'], action]
+        if 'newfile' in file_data:
+            id_args.append(file_data['newfile'])
+
+        event_id = uuid(*id_args)
 
         data = {
             "filename": file_data['file'],

--- a/releases/unreleased/event-id-generation-for-git-actions-updated.yml
+++ b/releases/unreleased/event-id-generation-for-git-actions-updated.yml
@@ -1,0 +1,9 @@
+---
+title: Event ID generation for Git actions updated
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Commits containing multiple copy file actions for the same file
+  generated duplicate event IDs because the new file name wasn’t
+  included in the ID calculation.


### PR DESCRIPTION
Commits containing copy file actions for the same file generated duplicate event IDs because the new file name wasn’t included in the ID calculation.

This PR improves event ID generation by considering the new file name when present.