### PR TITLE
Generate release notes for 1.0.0-alpha.1

### DIFF
--- a/releases/unreleased/grimoirelab-chronicler-major-release.yml
+++ b/releases/unreleased/grimoirelab-chronicler-major-release.yml
@@ -1,0 +1,9 @@
+---
+title: GrimoireLab Chronicler major release
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  First major release for GrimoireLab Chronicler providing the
+  initial library that converts raw items fetched by Perceval
+  into events for GrimoireLab.


### PR DESCRIPTION
Generate release notes for the first alpha version

This file is necessary because the current release workflow requires a changelog to generate a new alpha major version.
